### PR TITLE
Enable HTTP proxy for requests

### DIFF
--- a/config.example.php
+++ b/config.example.php
@@ -15,3 +15,7 @@ $backup_closed_boards = false;
 
 // Backup all Trello Boards from the organizations that the user has read access to
 $backup_all_organization_boards = false;
+
+// HTTP proxy, if one is required, in the format 'host:port', e.g. 'proxy.example.com:80' or '192.168.1.254:8080'
+$proxy= '';
+


### PR DESCRIPTION
Add '$proxy' config variable for users to specify an HTTP proxy if their
network environment requires one. If the variable is not defined, the
original behaviour is preserved.
