### PR TITLE
Username isn't required any more

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Usage
 	`git clone https://github.com/mattab/trello-backup.git trello-backup`
 - Duplicate the `config.example.php` file to `config.php` and fill in your details (as follows)
 - With your browser go to: [https://trello.com/1/appKey/generate](https://trello.com/1/appKey/generate) - It will give you your public 'Key' for Trello API.
-- Edit the file trello-backup/config.php and set `$key` to your 'Key', and set `$username` to your Trello.com username (without the at sign `@`)
+- Edit the file trello-backup/config.php and set `$key` to your 'Key'.
 - Then Run the script:
 	`php5 trello-backup/trello-backup.php`
 	It will output a URL that you can visit with your browser to get the Application Token. Visit this URL. Then click 'Allow' and copy the token string.

--- a/config.example.php
+++ b/config.example.php
@@ -7,10 +7,7 @@ $path = '.';
 // Key from https://trello.com/1/appKey/generate
 $key = 'here_put_your_Key';
 
-// Your Trello username
-$username = 'here_your_username_WITHOUT_the_@_symbol';
-
-// Your Application Token (set $key and $username only, then run the trello-backup.php to obtain your application_token to set below
+// Your Application Token (set $key only, then run the trello-backup.php to obtain your application_token to set below)
 $application_token = 'Here_your_app_token';
 
 // By default we don't backup closed boards (less clutter)

--- a/trello-backup.php
+++ b/trello-backup.php
@@ -38,7 +38,7 @@ if (!empty($proxy)) {
 
 // 1) Fetch all Trello Boards
 $application_token = trim($application_token);
-$url_boards = "https://api.trello.com/1/members/$username/boards?&key=$key&token=$application_token";
+$url_boards = "https://api.trello.com/1/members/me/boards?&key=$key&token=$application_token";
 $response = file_get_contents($url_boards, false, $ctx);
 $boardsInfo = json_decode($response);
 if(empty($boardsInfo)) {
@@ -46,7 +46,7 @@ if(empty($boardsInfo)) {
 }
 
 // 2) Fetch all Trello Organizations
-$url_organizations = "https://api.trello.com/1/members/$username/organizations?&key=$key&token=$application_token";
+$url_organizations = "https://api.trello.com/1/members/me/organizations?&key=$key&token=$application_token";
 $response = file_get_contents($url_organizations, false, $ctx);
 $organizationsInfo = json_decode($response);
 $organizations = array();


### PR DESCRIPTION
Using the script as-is failed with error 401, returning "invalid id". The docs don't seem to mention the username, just "me", which works. I haven't investigated if the API changed or something else.