### PR TITLE
bail out if file_get_contents() fails to fetch boards list

### DIFF
--- a/trello-backup.php
+++ b/trello-backup.php
@@ -40,6 +40,9 @@ if (!empty($proxy)) {
 $application_token = trim($application_token);
 $url_boards = "https://api.trello.com/1/members/me/boards?&key=$key&token=$application_token";
 $response = file_get_contents($url_boards, false, $ctx);
+if ($response === FALSE) {
+    die("Error requesting boards.\n");
+}
 $boardsInfo = json_decode($response);
 if(empty($boardsInfo)) {
     die("Error requesting your boards - maybe check your tokens are correct.\n");


### PR DESCRIPTION
My Trello backup cronjob recently failed because of what appeared to be a Trello malfunction while fetching the list of boards.  This patch introduces an error check for `file_get_contents()` to make the script bail when such a failure occurs.