### PR TITLE
Added feature to download attachments.

### DIFF
--- a/trello-backup.php
+++ b/trello-backup.php
@@ -118,7 +118,7 @@ foreach ($boards as $id => $board) {
             mkdir($dirname, 0777, true);
         }
 
-        file_put_contents($dirname . '/' . $member->data->attachment->name, file_get_contents($member->data->attachment->url));
+        file_put_contents($dirname . '/' . sanitize_file_name($member->data->attachment->name), file_get_contents($member->data->attachment->url));
         echo "\t'" . $member->data->attachment->name . "'\n";
     }
 }

--- a/trello-backup.php
+++ b/trello-backup.php
@@ -7,17 +7,20 @@
  * License: GPL v3 or later (I'm using that Wordpress function below and WP is released under GPL)
  */
 
-
-$config_file = 'config.php';
+if ($argc == 2) {
+    $config_file = $argv[1];
+} else {
+    $config_file = 'config.php';
+}
 
 require_once $config_file;
 
 // If the application_token looks incorrect we display help
-if(strlen($application_token) < 30) {
+if (strlen($application_token) < 30) {
     // 0) Fetch the Application tokenn
     // Source: https://trello.com/docs/gettingstarted/index.html#getting-a-token-from-a-user
     // We get the app token with "read" only access forever
-    $url_token = "https://trello.com/1/authorize?key=".$key."&name=My+Trello+Backup&expiration=never&response_type=token";
+    $url_token = "https://trello.com/1/authorize?key=" . $key . "&name=My+Trello+Backup&expiration=never&response_type=token";
     die("Go to this URL with your web browser (eg. Firefox) to authorize your Trello Backups to run:\n$url_token\n");
 }
 
@@ -26,7 +29,7 @@ $ctx = NULL;
 if (!empty($proxy)) {
     $aContext = array(
         'http' => array(
-            'proxy' => 'tcp://'.$proxy,
+            'proxy' => 'tcp://' . $proxy,
             'request_fullurl' => true
         )
     );
@@ -41,7 +44,7 @@ if ($response === FALSE) {
     die("Error requesting boards - maybe try again later and/or check your internet connection\n");
 }
 $boardsInfo = json_decode($response);
-if(empty($boardsInfo)) {
+if (empty($boardsInfo)) {
     die("Error requesting your boards - maybe check your tokens are correct.\n");
 }
 
@@ -50,17 +53,17 @@ $url_organizations = "https://api.trello.com/1/members/me/organizations?&key=$ke
 $response = file_get_contents($url_organizations, false, $ctx);
 $organizationsInfo = json_decode($response);
 $organizations = array();
-foreach($organizationsInfo as $org){
+foreach ($organizationsInfo as $org) {
     $organizations[$org->id] = $org->displayName;
 }
 
 // 3) Fetch all Trello Boards from the organizations that the user has read access to
-if($backup_all_organization_boards) {
-    foreach($organizations as $organization_id => $organization_name) {
+if ($backup_all_organization_boards) {
+    foreach ($organizations as $organization_id => $organization_name) {
         $url_boards = "https://api.trello.com/1/organizations/$organization_id/boards?&key=$key&token=$application_token";
         $response = file_get_contents($url_boards, false, $ctx);
         $organizationBoardsInfo = json_decode($response);
-        if(empty($organizationBoardsInfo)) {
+        if (empty($organizationBoardsInfo)) {
             die("Error requesting the organization $organization_name boards - maybe check your tokens are correct.\n");
         } else {
             $boardsInfo = array_merge($organizationBoardsInfo, $boardsInfo);
@@ -70,18 +73,18 @@ if($backup_all_organization_boards) {
 
 // 4) Only backup the "open" boards
 $boards = array();
-foreach($boardsInfo as $board) {
-    if(!$backup_closed_boards && $board->closed) {
+foreach ($boardsInfo as $board) {
+    if (!$backup_closed_boards && $board->closed) {
         continue;
     }
 
-    if(isset($ignore_boards) && in_array($board->name, $ignore_boards)) {
+    if (isset($ignore_boards) && in_array($board->name, $ignore_boards)) {
         continue;
     }
 
-    $boards[$board->id] = (object) array(
+    $boards[$board->id] = (object)array(
         "name" => $board->name,
-        "orgName" => (isset($organizations[$board->idOrganization])? $organizations[$board->idOrganization] : ''),
+        "orgName" => (isset($organizations[$board->idOrganization]) ? $organizations[$board->idOrganization] : ''),
         "closed" => (($board->closed) ? true : false)
     );
 }
@@ -89,26 +92,26 @@ foreach($boardsInfo as $board) {
 echo count($boards) . " boards to backup... \n";
 
 // 5) Backup now!
-foreach($boards as $id => $board) {
+foreach ($boards as $id => $board) {
     $url_individual_board_json = "https://api.trello.com/1/boards/$id?actions=all&actions_limit=1000&card_attachment_fields=all&cards=all&lists=all&members=all&member_fields=all&card_attachment_fields=all&checklists=all&fields=all&key=$key&token=$application_token";
     $dirname = "$path/trello"
         . (($board->closed) ? '-CLOSED' : '')
-        . (!empty($board->orgName) ? '-org-' . sanitize_file_name($board->orgName) : '' )
+        . (!empty($board->orgName) ? '-org-' . sanitize_file_name($board->orgName) : '')
         . '-board-' . sanitize_file_name($board->name)
         . (($filename_append_datetime) ? '-' . date($filename_append_datetime, time()) : '');
     $filename = $dirname . '.json';
-    echo "recording $id ".(($board->closed)?'the closed ':'')."board '".$board->name."' with organization '".$board->orgName."' in filename $filename...\n";
+    echo "recording $id " . (($board->closed) ? 'the closed ' : '') . "board '" . $board->name . "' with organization '" . $board->orgName . "' in filename $filename...\n";
     $response = file_get_contents($url_individual_board_json, false, $ctx);
     $decoded = json_decode($response);
-    if(empty($decoded)) {
+    if (empty($decoded)) {
         die("The board '$board->name' or organization '$board->orgName' could not be downloaded, response was : $response ");
     }
-    file_put_contents( $filename, $response );
+    file_put_contents($filename, $response);
 
     // 5a) Backup the files
     $trelloObject = json_decode($response);
     foreach ($trelloObject->actions as $member) {
-        if(!isset($member->data->attachment->url))
+        if (!isset($member->data->attachment->url))
             continue;
 
         if (!file_exists($dirname)) {
@@ -116,7 +119,7 @@ foreach($boards as $id => $board) {
         }
 
         file_put_contents($dirname . '/' . $member->data->attachment->name, file_get_contents($member->data->attachment->url));
-        echo "\tAttachment downloaded: '" . $member->data->attachment->name . "'\n";
+        echo "\t'" . $member->data->attachment->name . "'\n";
     }
 }
 echo "your Trello boards are now safely downloaded!\n";
@@ -135,7 +138,8 @@ echo "your Trello boards are now safely downloaded!\n";
  * @param string $filename The filename to be sanitized
  * @return string The sanitized filename
  */
-function sanitize_file_name( $filename ) {
+function sanitize_file_name($filename)
+{
     $special_chars = array("?", "[", "]", "/", "\\", "=", "<", ">", ":", ";", ",", "'", "\"", "&", "$", "#", "*", "(", ")", "|", "~", "`", "!", "{", "}");
     $filename = str_replace($special_chars, '', $filename);
     $filename = preg_replace('/[\s-]+/', '-', $filename);


### PR DESCRIPTION
Attachments will now be automatically downloaded for each board.

Example:
Attachments of board `Product ideas` of organization `ACME` will be saved to `$path/trello-org-ACME-Product-ideas/<attachment-name>`