### PR TITLE
Check for config file, use absolute path, improve error message, if there are no boards to backup

### DIFF
--- a/trello-backup.php
+++ b/trello-backup.php
@@ -10,9 +10,13 @@
 if ($argc == 2) {
     $config_file = $argv[1];
 } else {
-    $config_file = 'config.php';
+    $config_file = __DIR__ . DIRECTORY_SEPARATOR . 'config.php';
 }
 
+// check config file exits
+if (!file_exists($config_file)) {
+    die("Please duplicate the config.example.php file to config.php and fill in your details (as follows).");
+}
 require_once $config_file;
 
 // If the application_token looks incorrect we display help

--- a/trello-backup.php
+++ b/trello-backup.php
@@ -95,6 +95,9 @@ foreach ($boardsInfo as $board) {
         "closed" => (($board->closed) ? true : false)
     );
 }
+if (empty($boards)) {
+    die("Error: No boards found in your account. Please review your configuration or start by adding a board to your account.");
+}
 
 echo count($boards) . " boards to backup... \n";
 


### PR DESCRIPTION
1. The config file path is now absolute, in case there is any problems running the script.
2. If the user didn't duplicate the config file he will see a php error, this was fixed using a kind message.
3. Improve error message, if there are no boards to backup (#22)