### PR TITLE
Add option for GDrive attachments, save GDrive attachments correctly

### DIFF
--- a/config.example.php
+++ b/config.example.php
@@ -16,6 +16,9 @@ $backup_all_organization_boards = false;
 // Backup all cards' attachments in a subfolder for each Trello board
 $backup_attachments = false;
 
+// Backup Google Drive attachments as link (.url file)
+$backup_gdrive_attachments = false;
+
 // Where to store the backup files (by default, trello boards JSON files will be stored in this directory)
 $path = dirname(__FILE__);
 

--- a/trello-backup.php
+++ b/trello-backup.php
@@ -124,6 +124,9 @@ foreach ($boards as $id => $board) {
         $attachments = array();
         foreach ($trelloObject->actions as $member) {
             if (isset($member->data->attachment->url)) {
+                if (strpos($member->data->attachment->url, 'drive.google.com/file') !== false && !$backup_gdrive_attachments) {
+                    continue;
+                }
                 $attachments[$member->data->attachment->url] = $member->data->attachment->id . '-' . $member->data->attachment->name;
             }
         }
@@ -137,7 +140,12 @@ foreach ($boards as $id => $board) {
             $i = 1;
             foreach ($attachments as $url => $name) {
                 $pathForAttachment = $dirname . '/' . sanitize_file_name($name);
-                file_put_contents($pathForAttachment, file_get_contents($url));
+                if (strpos($url, 'drive.google.com/file') !== false) {
+                    $url_file_content = "[InternetShortcut]\nURL=" . $url . "\n";
+                    file_put_contents($pathForAttachment . '.url', $url_file_content);
+                } else {
+                    file_put_contents($pathForAttachment, file_get_contents($url));
+                }
                 echo "\t" . $i++ . ") " . $name . " in " . $pathForAttachment . "\n";
             }
         }


### PR DESCRIPTION
This PR fixes #37

Changes made: 

Attachment URLs will be checked if they are Google Drive links.
- If so **and** `$backup_gdrive_attachments` is `true`, they will be downloaded as clickable links (.url-file)
- If `$backup_gdrive_attachments` is `false` Google Drive attachments will be skipped.

Downloading the attachment itself is not possible easily.
This would add the Google API + extra authentication. There is a hacky way of downloading the HTML file and parsing the DOM, but this wouldn't be safe for a backup job at all.

---

But if you really need to backup the Google Drive attachments, this changes could also support this.

The [URL file format](http://www.lyberty.com/encyc/articles/tech/dot_url_format_-_an_unofficial_guide.html) is pretty simple - it's just an [INI file](https://en.wikipedia.org/wiki/INI_file) - so you could parse all `.url` files and receive the `URL`, and from here just call Google's API:

- Link from Trello: `https://drive.google.com/file/d/1flZqT3LA9Za0uK0nHgOndjlP9vOkviIs/view?usp=drive_web`
- Extract fileId from URL: `fileId = 1flZqT3LA9Za0uK0nHgOndjlP9vOkviIs`
- Download file with [Google Drive REST API](https://developers.google.com/drive/api/v3/manage-downloads):

```HTTP
GET https://www.googleapis.com/drive/v3/files/1flZqT3LA9Za0uK0nHgOndjlP9vOkviIs?alt=media
Authorization: Bearer <ACCESS_TOKEN>
```