### PR TITLE
Fix 46 - Set a default time zone (using config)

### DIFF
--- a/config.example.php
+++ b/config.example.php
@@ -31,3 +31,6 @@ $boards_to_download = array();
 
 // Timestamp format, e.g. 'Y-m-d_H-i-s'
 $filename_append_datetime = false;
+
+//Timezone, e.g. UTC
+$timezone = 'UTC';

--- a/trello-backup.php
+++ b/trello-backup.php
@@ -19,6 +19,13 @@ if (!file_exists($config_file)) {
 }
 require_once $config_file;
 
+if(!isset($timezone))
+{
+	$timezone = "UTC";
+	print "No timezone set in config ($config_file), using $timezone\n";
+}
+date_default_timezone_set($timezone);
+
 // If the application_token looks incorrect we display help
 if (strlen($application_token) < 30) {
     // 0) Fetch the Application tokenn


### PR DESCRIPTION
Fixes 46 by adding a new config option "Timezone", and using it. If not set via config, use UTC.