### PR TITLE
Switch to curl instead of file_get_contents to fix http error

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Trello-Backup
 
 Requirements
 ---
-This is a simple php script which requires PHP installed on your system:
-`sudo apt-get install php7`
+This is a simple php script which requires PHP with curl-support installed on your system:
+`sudo apt-get install php7 php-curl`
 
 Usage
 ---

--- a/trello-backup.php
+++ b/trello-backup.php
@@ -50,7 +50,8 @@ if (!empty($proxy)) {
 // 1) Fetch all Trello Boards
 $application_token = trim($application_token);
 $url_boards = "https://api.trello.com/1/members/me/boards?&key=$key&token=$application_token";
-$response = file_get_contents($url_boards, false, $ctx);
+$response 	= do_request($url_boards);
+
 if ($response === false) {
     die("Error requesting boards - maybe try again later and/or check your internet connection\n");
 }
@@ -205,4 +206,22 @@ function create_backup_dir($dirname)
 	{
 		die("Error creating backup dir - directory $dirname is not writeable\n");
 	}
+}
+
+/**
+ * @param $url The url to fetch
+ * @return string Output from the server, or false on error
+ */
+function do_request($url)
+{
+	global $proxy;
+	$ch = curl_init();
+	curl_setopt($ch, CURLOPT_URL, $url);
+	curl_setopt($ch, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2_0);
+	curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+	// disclaimer: I don't have a proxy to test this with, but *should* work
+	curl_setopt($ch, CURLOPT_PROXY, $proxy);
+	$response = curl_exec($ch);
+	curl_close ($ch);
+	return $response;
 }

--- a/trello-backup.php
+++ b/trello-backup.php
@@ -35,18 +35,6 @@ if (strlen($application_token) < 30) {
     die("Go to this URL with your web browser (eg. Firefox) to authorize your Trello Backups to run:\n$url_token\n");
 }
 
-// Prepare proxy configuration if necessary
-$ctx = null;
-if (!empty($proxy)) {
-    $aContext = array(
-        'http' => array(
-            'proxy' => 'tcp://' . $proxy,
-            'request_fullurl' => true
-        )
-    );
-    $ctx = stream_context_create($aContext);
-}
-
 // 1) Fetch all Trello Boards
 $application_token = trim($application_token);
 $url_boards = "https://api.trello.com/1/members/me/boards?&key=$key&token=$application_token";

--- a/trello-backup.php
+++ b/trello-backup.php
@@ -50,7 +50,7 @@ if (empty($boardsInfo)) {
 
 // 2) Fetch all Trello Organizations
 $url_organizations = "https://api.trello.com/1/members/me/organizations?&key=$key&token=$application_token";
-$response = file_get_contents($url_organizations, false, $ctx);
+$response = do_request($url_organizations);
 $organizationsInfo = json_decode($response);
 $organizations = array();
 foreach ($organizationsInfo as $org) {
@@ -61,7 +61,7 @@ foreach ($organizationsInfo as $org) {
 if ($backup_all_organization_boards) {
     foreach ($organizations as $organization_id => $organization_name) {
         $url_boards = "https://api.trello.com/1/organizations/$organization_id/boards?&key=$key&token=$application_token";
-        $response = file_get_contents($url_boards, false, $ctx);
+        $response = do_request($url_boards);
         $organizationBoardsInfo = json_decode($response);
         if (empty($organizationBoardsInfo)) {
             die("Error requesting the organization $organization_name boards - maybe check your tokens are correct.\n");
@@ -113,7 +113,7 @@ foreach ($boards as $id => $board) {
     $filename = $dirname . '.json';
 
     echo "recording " . (($board->closed) ? 'the closed ' : '') . "board '" . $board->name . "' " . (empty($board->orgName) ? "" : "(within organization '" . $board->orgName . "')") . " in filename $filename ...\n";
-    $response = file_get_contents($url_individual_board_json, false, $ctx);
+    $response = do_request($url_individual_board_json);
     $decoded = json_decode($response);
     if (empty($decoded)) {
         die("The board '$board->name' or organization '$board->orgName' could not be downloaded, response was : $response ");


### PR DESCRIPTION
It seems like Trello suddenly(?) decided to require a higher HTTP-version. See #52 

I couldn't figure out a way to fix it with `file_get_contents()`, so I switched to `curl`. This _does_ mean that users would need curl support installed, but at least the script works again. For me that's a good trade-off.

Proxy support should still work, though I haven't been able to test it myself.