### PR TITLE
Fix some attachments requiring a new authorisation method

### DIFF
--- a/trello-backup.php
+++ b/trello-backup.php
@@ -156,8 +156,26 @@ foreach ($boards as $id => $board) {
             $i = 1;
             foreach ($attachments as $url => $name) {
                 $pathForAttachment = $dirname . '/' . sanitize_file_name($name);
-                file_put_contents($pathForAttachment, file_get_contents($url, false, $ctx));
-                echo "\t" . $i++ . ") " . $name . " in " . $pathForAttachment . "\n";
+                echo "\t" . $i++ . ") " . $name . "\n";
+
+                # try without the extra auth headers for one type of URL, and with for another
+                echo "\t\t trying without extra auth headers...\n";
+                $contents = file_get_contents($url, false, $ctx);
+                if ($contents) {
+                    file_put_contents($pathForAttachment, $contents);
+                    echo "\t\t\t it worked. Putting in " . $pathForAttachment . "\n";
+                }
+                else {
+                    echo "\t\t Didn't work. Trying with extra auth headers...\n";
+                    $contents = file_get_contents($url);
+                    if ($contents) {
+                        file_put_contents($pathForAttachment, $contents);
+                        echo "\t\t\t it worked. Putting in " . $pathForAttachment . "\n";
+                    }
+                    else {
+                        echo "\t\t\t it didn't work either\n";
+                    }
+                }
             }
         }
     }

--- a/trello-backup.php
+++ b/trello-backup.php
@@ -44,6 +44,8 @@ if (!empty($proxy)) {
         'request_fullurl' => true
     );
 }
+// pass the keys in via header to allow retrieval from S3
+$context['http']['header'] = "Authorization: OAuth oauth_consumer_key=\"$key\", oauth_token=\"$application_token\"";
 
 // Force protocol to HTTP 1.1 to avoid error
 $context['http']['protocol_version'] = '1.1';
@@ -154,7 +156,7 @@ foreach ($boards as $id => $board) {
             $i = 1;
             foreach ($attachments as $url => $name) {
                 $pathForAttachment = $dirname . '/' . sanitize_file_name($name);
-                file_put_contents($pathForAttachment, file_get_contents($url));
+                file_put_contents($pathForAttachment, file_get_contents($url, false, $ctx));
                 echo "\t" . $i++ . ") " . $name . " in " . $pathForAttachment . "\n";
             }
         }


### PR DESCRIPTION
This adds the extra headers to the S3 calls where required. Similar to https://github.com/mattab/trello-backup/pull/59, but I found using headers on all caused some to fail so I configured it to fall back to no headers where required. Maybe just older attachments?